### PR TITLE
Optional url decoding

### DIFF
--- a/Cache/CacheElement.php
+++ b/Cache/CacheElement.php
@@ -53,9 +53,9 @@ class CacheElement
      *
      * @param string $path Cache path, eg. /sandbox
      */
-    public function setPath($path)
+    public function setPath($path, $decode = true)
     {
-        $this->path = urldecode($path);
+        $this->path = $decode === true ? urldecode($path) : $path;
     }
 
     /**

--- a/Cache/CacheElement.php
+++ b/Cache/CacheElement.php
@@ -53,9 +53,19 @@ class CacheElement
      *
      * @param string $path Cache path, eg. /sandbox
      */
-    public function setPath($path, $decode = true)
+    public function setPath($path)
     {
-        $this->path = $decode === true ? urldecode($path) : $path;
+        $this->path = urldecode($path);
+    }
+
+    /**
+     * Sets cached element path without url decoding
+     *
+     * @param string $path Cache path, eg. /sandbox
+     */
+    public function setRawPath($path)
+    {
+        $this->path = $path;
     }
 
     /**


### PR DESCRIPTION
I got supercache working with GET parameters on nginx but I had to disable urldecode() to make the server able to match requests with many nested parameters.
I don't know how it works on Apache or Litespeed so I just made it optional.
